### PR TITLE
Pin OpenScale version to 1.0.429 .

### DIFF
--- a/examples/exampleNotebook.ipynb
+++ b/examples/exampleNotebook.ipynb
@@ -84,7 +84,7 @@
     }
    ],
    "source": [
-    "!pip install --upgrade ibm-ai-openscale --no-cache | tail -n 1"
+    "!pip install ibm-ai-openscale==1.0.429 --no-cache | tail -n 1"
    ]
   },
   {

--- a/notebooks/AIOpenScaleAndCustomMLEngine.ipynb
+++ b/notebooks/AIOpenScaleAndCustomMLEngine.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade ibm-ai-openscale --no-cache | tail -n 1"
+    "!pip install ibm-ai-openscale==1.0.429 --no-cache | tail -n 1"
    ]
   },
   {


### PR DESCRIPTION
New notebook for version 2.x will follow after testing and updates
for new data set.
This is a workaround.

Partial Fix: #9