### PR TITLE
Fix path for `Deploy to IBMCloud` button.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Create the following services:
 
 ### 4a. Deploy to IBM Cloud
 
-[![Deploy to IBM Cloud](https://cloud.ibm.com/devops/setup/deploy/button.png)](https://cloud.ibm.com/devops/setup/deploy?repository=https://github.com/IBM/monitor-custom-ml-engine-with-watson-openscale/tree/cfButton)
+[![Deploy to IBM Cloud](https://cloud.ibm.com/devops/setup/deploy/button.png)](https://cloud.ibm.com/devops/setup/deploy?repository=https://github.com/IBM/monitor-custom-ml-engine-with-watson-openscale)
 
 Click the ``Deploy to IBM Cloud`` button and hit ``Create`` and then jump to step 5.
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,3 +8,4 @@ applications:
   memory: 256MB
   name: custom-ml-server
   timeout: 180
+  random-route: false


### PR DESCRIPTION
The URL to `Deploy to IBMCloud` had `cfButton` appended to
the URL, which is wrong. Remove it.